### PR TITLE
Fix DEPRECATION WARNING: to_prepare is deprecated and will be removed…

### DIFF
--- a/lib/mongoid/observers/railtie.rb
+++ b/lib/mongoid/observers/railtie.rb
@@ -17,7 +17,7 @@ module Mongoid
         ActiveSupport.on_load(:mongoid) do
           ::Mongoid::instantiate_observers
 
-          ActionDispatch::Reloader.to_prepare do
+          ActiveSupport::Reloader.to_prepare do
             ::Mongoid.instantiate_observers
           end
         end


### PR DESCRIPTION
… from Rails 5.2
